### PR TITLE
ci: Call reusable-release-policy-catalog workflow on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,3 +211,14 @@ jobs:
               prerelease: isPreRelease,
               make_latest: !isPreRelease
             });
+
+  release-catalog:
+    needs: [calculate-policy-from-tag, release]
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-catalog.yml@247608f0b5a1562a6fd2576e5b2e6cbe62551baf # v4.5.15
+    with:
+      policy-name: ${{ needs.calculate-policy-from-tag.outputs.policy-name }}
+      policy-working-dir: ${{ needs.calculate-policy-from-tag.outputs.policy-working-dir }}
+    secrets:
+      # Required to dispatch the release event to the policy-catalog repository
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION


## Description

Extend the release workflow to call the already existing reusable workflow `reusable-release-policy-catalog`.

This is the same workflow we call in the Rego policies library.

Fix https://github.com/kubewarden/policies/issues/42

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
TBD.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
