### PR TITLE
fix: adds context-aware-demo as workspace member.

### DIFF
--- a/policies/Cargo.toml
+++ b/policies/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "annotations-policy",
   "apparmor-psp-policy",
   "capabilities-psp-policy",
+  "context-aware-demo",
   "deprecated-api-versions-policy",
   "do-not-expose-admission-controller-webhook-services-policy",
   "echo",


### PR DESCRIPTION
## Description

Updates the Cargo.toml of the Rust workspace adding the context-aware-demo policy as workspace member.

Related to https://github.com/kubewarden/kubewarden-controller/issues/1251

This PR is necessary to fix CI [error](https://github.com/kubewarden/policies/actions/runs/20931414727/job/60143023238)

