### PR TITLE
fix(ci): run release tag job on policies changes.

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -2,6 +2,14 @@ on:
   pull_request:
     types:
       - closed
+    paths:
+      # This workflow is run when a PR is closed to trigger policy release. If
+      # the PR does not change any file under policies directory there is no
+      # need to run it.
+      - "policies/**"
+      # If a PR has changes inside the policies/crates only. There is no need to
+      # trigger this job to release policies
+      - "!policies/crates/**"
   workflow_dispatch:
     inputs:
       policy-working-dir:


### PR DESCRIPTION
## Description

Updates the release-tag.yaml file run the jobs when a pull request is closed only if there is a change on some policy. Otherwise, there is no need to release the job. There is no policy to be tagged and released.

Related to https://github.com/kubewarden/kubewarden-controller/issues/1257