### PR TITLE
fix(deps): fix renovatebot configuration.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   },
   "packageRules": [
     {
-      "_comment": "bundle dependencies updates together",
+      "description": "bundle dependencies updates together",
       "matchUpdateTypes": [
         "patch",
         "minor",


### PR DESCRIPTION
## Description

The renovate.json file has a field name in the packageRules configuration called "_comment" that does not exist. Rename it to "description"

Fix https://github.com/kubewarden/policies/issues/46
