### PR TITLE
fix: Tinygo Makefile build & golangci targets

### DIFF
--- a/policies/Makefile.tinygo
+++ b/policies/Makefile.tinygo
@@ -10,9 +10,9 @@ else
 	docker run \
 		--rm \
 		-e GOFLAGS="-buildvcs=false" \
-		-v $(ROOT_DIR):/src \
+		-v $(ROOT_DIR)$(POLICY_DIR):/src \
 		-w /src tinygo/tinygo:0.39.0 \
-		tinygo build -o $(POLICY_DIR)/policy.wasm -target=wasi -no-debug ./$(POLICY_DIR)
+		tinygo build -o policy.wasm -target=wasi -no-debug .
 endif
 
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
This is needed for all PRs importing TinyGo policies to succeed.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested locally.

Also rebased one of the PRs to see it work: https://github.com/kubewarden/policies/pull/50
I will repush that branch without me as committer later on, as that is not necessary.


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
