### PR TITLE
ci: Install opa cli as part of install-dependencies action

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -20,6 +20,10 @@ inputs:
     description: "binaryen release to be installed"
     required: false
     default: "116"
+  OPA_VERSION:
+    description: "opa release to be installed"
+    required: false
+    default: "v0.65.0"
 runs:
   using: "composite"
   steps:
@@ -123,3 +127,12 @@ runs:
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
     - name: Install updatecli
       uses: updatecli/updatecli-action@4fd2c16d992120bd5355264a03ad0cddec013e1b # v2.99.0
+    - name: Install OPA
+      shell: bash
+      run: |
+        set -e
+        INSTALL_DIR=$HOME/.opa
+        mkdir -p $INSTALL_DIR
+        curl -sL https://github.com/open-policy-agent/opa/releases/download/${{ inputs.OPA_VERSION || 'v0.65.0' }}/opa_linux_amd64_static -o $INSTALL_DIR/opa
+        chmod 755 $INSTALL_DIR/opa
+        echo $INSTALL_DIR >> $GITHUB_PATH


### PR DESCRIPTION
## Description

Needed for Rego CI jobs.

Taken from https://github.com/kubewarden/github-actions/blob/main/opa-installer/action.yml.

Maintaining the same opa version used.
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Not tested. What can go wrong.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
