### PR TITLE
fix(ci): fix typo in release drafter configuration.

### DIFF
--- a/.github/release-drafter-allow-privilege-escalation-psp-policy.yml
+++ b/.github/release-drafter-allow-privilege-escalation-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "allow-privilege-escalation-psp-policy/v$RESOLVED_VERSION"
 tag-template: "allow-privilege-escalation-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: allow-privilege-escalation-psp-policy/v

--- a/.github/release-drafter-allowed-fsgroups-psp-policy.yml
+++ b/.github/release-drafter-allowed-fsgroups-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "allowed-fsgroups-psp-policy/v$RESOLVED_VERSION"
 tag-template: "allowed-fsgroups-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: allowed-fsgroups-psp-policy/v

--- a/.github/release-drafter-allowed-proc-mount-types-psp-policy.yml
+++ b/.github/release-drafter-allowed-proc-mount-types-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "allowed-proc-mount-types-psp-policy/v$RESOLVED_VERSION"
 tag-template: "allowed-proc-mount-types-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: allowed-proc-mount-types-psp-policy/v

--- a/.github/release-drafter-annotations-policy.yml
+++ b/.github/release-drafter-annotations-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "annotations-policy/v$RESOLVED_VERSION"
 tag-template: "annotations-policy/v$RESOLVED_VERSION"
 tag-prefix: annotations-policy/v

--- a/.github/release-drafter-apparmor-psp-policy.yml
+++ b/.github/release-drafter-apparmor-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "apparmor-psp-policy/v$RESOLVED_VERSION"
 tag-template: "apparmor-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: apparmor-psp-policy/v

--- a/.github/release-drafter-capabilities-psp-policy.yml
+++ b/.github/release-drafter-capabilities-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "capabilities-psp-policy/v$RESOLVED_VERSION"
 tag-template: "capabilities-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: capabilities-psp-policy/v

--- a/.github/release-drafter-cel-policy.yml
+++ b/.github/release-drafter-cel-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "cel-policy/v$RESOLVED_VERSION"
 tag-template: "cel-policy/v$RESOLVED_VERSION"
 tag-prefix: cel-policy/v

--- a/.github/release-drafter-container-resources-policy.yml
+++ b/.github/release-drafter-container-resources-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "container-resources-policy/v$RESOLVED_VERSION"
 tag-template: "container-resources-policy/v$RESOLVED_VERSION"
 tag-prefix: container-resources-policy/v

--- a/.github/release-drafter-context-aware-demo.yml
+++ b/.github/release-drafter-context-aware-demo.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "context-aware-demo/v$RESOLVED_VERSION"
 tag-template: "context-aware-demo/v$RESOLVED_VERSION"
 tag-prefix: context-aware-demo/v

--- a/.github/release-drafter-deprecated-api-versions-policy.yml
+++ b/.github/release-drafter-deprecated-api-versions-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "deprecated-api-versions-policy/v$RESOLVED_VERSION"
 tag-template: "deprecated-api-versions-policy/v$RESOLVED_VERSION"
 tag-prefix: deprecated-api-versions-policy/v

--- a/.github/release-drafter-do-not-expose-admission-controller-webhook-services-policy.yml
+++ b/.github/release-drafter-do-not-expose-admission-controller-webhook-services-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "do-not-expose-admission-controller-webhook-services-policy/v$RESOLVED_VERSION"
 tag-template: "do-not-expose-admission-controller-webhook-services-policy/v$RESOLVED_VERSION"
 tag-prefix: do-not-expose-admission-controller-webhook-services-policy/v

--- a/.github/release-drafter-echo.yml
+++ b/.github/release-drafter-echo.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "echo/v$RESOLVED_VERSION"
 tag-template: "echo/v$RESOLVED_VERSION"
 tag-prefix: echo/v

--- a/.github/release-drafter-env-variable-secrets-scanner-policy.yml
+++ b/.github/release-drafter-env-variable-secrets-scanner-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "env-variable-secrets-scanner-policy/v$RESOLVED_VERSION"
 tag-template: "env-variable-secrets-scanner-policy/v$RESOLVED_VERSION"
 tag-prefix: env-variable-secrets-scanner-policy/v

--- a/.github/release-drafter-environment-variable-policy.yml
+++ b/.github/release-drafter-environment-variable-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "environment-variable-policy/v$RESOLVED_VERSION"
 tag-template: "environment-variable-policy/v$RESOLVED_VERSION"
 tag-prefix: environment-variable-policy/v

--- a/.github/release-drafter-flexvolume-drivers-psp-policy.yml
+++ b/.github/release-drafter-flexvolume-drivers-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "flexvolume-drivers-psp-policy/v$RESOLVED_VERSION"
 tag-template: "flexvolume-drivers-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: flexvolume-drivers-psp-policy/v

--- a/.github/release-drafter-go-wasi-context-aware-test-policy.yml
+++ b/.github/release-drafter-go-wasi-context-aware-test-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "go-wasi-context-aware-test-policy/v$RESOLVED_VERSION"
 tag-template: "go-wasi-context-aware-test-policy/v$RESOLVED_VERSION"
 tag-prefix: go-wasi-context-aware-test-policy/v

--- a/.github/release-drafter-host-namespaces-psp-policy.yml
+++ b/.github/release-drafter-host-namespaces-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "host-namespaces-psp-policy/v$RESOLVED_VERSION"
 tag-template: "host-namespaces-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: host-namespaces-psp-policy/v

--- a/.github/release-drafter-hostpaths-psp-policy.yml
+++ b/.github/release-drafter-hostpaths-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "hostpaths-psp-policy/v$RESOLVED_VERSION"
 tag-template: "hostpaths-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: hostpaths-psp-policy/v

--- a/.github/release-drafter-image-cve-policy.yml
+++ b/.github/release-drafter-image-cve-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "image-cve-policy/v$RESOLVED_VERSION"
 tag-template: "image-cve-policy/v$RESOLVED_VERSION"
 tag-prefix: image-cve-policy/v

--- a/.github/release-drafter-ingress-policy.yml
+++ b/.github/release-drafter-ingress-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "ingress-policy/v$RESOLVED_VERSION"
 tag-template: "ingress-policy/v$RESOLVED_VERSION"
 tag-prefix: ingress-policy/v

--- a/.github/release-drafter-labels-policy.yml
+++ b/.github/release-drafter-labels-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "labels-policy/v$RESOLVED_VERSION"
 tag-template: "labels-policy/v$RESOLVED_VERSION"
 tag-prefix: labels-policy/v

--- a/.github/release-drafter-namespace-label-propagator-policy.yml
+++ b/.github/release-drafter-namespace-label-propagator-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "namespace-label-propagator-policy/v$RESOLVED_VERSION"
 tag-template: "namespace-label-propagator-policy/v$RESOLVED_VERSION"
 tag-prefix: namespace-label-propagator-policy/v

--- a/.github/release-drafter-persistentvolumeclaim-storageclass-policy.yml
+++ b/.github/release-drafter-persistentvolumeclaim-storageclass-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "persistentvolumeclaim-storageclass-policy/v$RESOLVED_VERSION"
 tag-template: "persistentvolumeclaim-storageclass-policy/v$RESOLVED_VERSION"
 tag-prefix: persistentvolumeclaim-storageclass-policy/v

--- a/.github/release-drafter-pod-ndots-policy.yml
+++ b/.github/release-drafter-pod-ndots-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "pod-ndots-policy/v$RESOLVED_VERSION"
 tag-template: "pod-ndots-policy/v$RESOLVED_VERSION"
 tag-prefix: pod-ndots-policy/v

--- a/.github/release-drafter-pod-privileged-policy.yml
+++ b/.github/release-drafter-pod-privileged-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "pod-privileged-policy/v$RESOLVED_VERSION"
 tag-template: "pod-privileged-policy/v$RESOLVED_VERSION"
 tag-prefix: pod-privileged-policy/v

--- a/.github/release-drafter-pod-runtime-class-policy.yml
+++ b/.github/release-drafter-pod-runtime-class-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "pod-runtime-class-policy/v$RESOLVED_VERSION"
 tag-template: "pod-runtime-class-policy/v$RESOLVED_VERSION"
 tag-prefix: pod-runtime-class-policy/v

--- a/.github/release-drafter-priority-class-policy.yml
+++ b/.github/release-drafter-priority-class-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "priority-class-policy/v$RESOLVED_VERSION"
 tag-template: "priority-class-policy/v$RESOLVED_VERSION"
 tag-prefix: priority-class-policy/v

--- a/.github/release-drafter-probes-policy.yml
+++ b/.github/release-drafter-probes-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "probes-policy/v$RESOLVED_VERSION"
 tag-template: "probes-policy/v$RESOLVED_VERSION"
 tag-prefix: probes-policy/v

--- a/.github/release-drafter-psa-label-enforcer-policy.yml
+++ b/.github/release-drafter-psa-label-enforcer-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "psa-label-enforcer-policy/v$RESOLVED_VERSION"
 tag-template: "psa-label-enforcer-policy/v$RESOLVED_VERSION"
 tag-prefix: psa-label-enforcer-policy/v

--- a/.github/release-drafter-rancher-project-quotas-namespace-validator.yml
+++ b/.github/release-drafter-rancher-project-quotas-namespace-validator.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "rancher-project-quotas-namespace-validator/v$RESOLVED_VERSION"
 tag-template: "rancher-project-quotas-namespace-validator/v$RESOLVED_VERSION"
 tag-prefix: rancher-project-quotas-namespace-validator/v

--- a/.github/release-drafter-raw-mutation-policy.yml
+++ b/.github/release-drafter-raw-mutation-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "raw-mutation-policy/v$RESOLVED_VERSION"
 tag-template: "raw-mutation-policy/v$RESOLVED_VERSION"
 tag-prefix: raw-mutation-policy/v

--- a/.github/release-drafter-raw-mutation-wasi-policy.yml
+++ b/.github/release-drafter-raw-mutation-wasi-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "raw-mutation-wasi-policy/v$RESOLVED_VERSION"
 tag-template: "raw-mutation-wasi-policy/v$RESOLVED_VERSION"
 tag-prefix: raw-mutation-wasi-policy/v

--- a/.github/release-drafter-raw-validation-policy.yml
+++ b/.github/release-drafter-raw-validation-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "raw-validation-policy/v$RESOLVED_VERSION"
 tag-template: "raw-validation-policy/v$RESOLVED_VERSION"
 tag-prefix: raw-validation-policy/v

--- a/.github/release-drafter-raw-validation-wasi-policy.yml
+++ b/.github/release-drafter-raw-validation-wasi-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "raw-validation-wasi-policy/v$RESOLVED_VERSION"
 tag-template: "raw-validation-wasi-policy/v$RESOLVED_VERSION"
 tag-prefix: raw-validation-wasi-policy/v

--- a/.github/release-drafter-readonly-root-filesystem-psp-policy.yml
+++ b/.github/release-drafter-readonly-root-filesystem-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "readonly-root-filesystem-psp-policy/v$RESOLVED_VERSION"
 tag-template: "readonly-root-filesystem-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: readonly-root-filesystem-psp-policy/v

--- a/.github/release-drafter-safe-annotations-policy.yml
+++ b/.github/release-drafter-safe-annotations-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "safe-annotations-policy/v$RESOLVED_VERSION"
 tag-template: "safe-annotations-policy/v$RESOLVED_VERSION"
 tag-prefix: safe-annotations-policy/v

--- a/.github/release-drafter-safe-labels-policy.yml
+++ b/.github/release-drafter-safe-labels-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "safe-labels-policy/v$RESOLVED_VERSION"
 tag-template: "safe-labels-policy/v$RESOLVED_VERSION"
 tag-prefix: safe-labels-policy/v

--- a/.github/release-drafter-seccomp-psp-policy.yml
+++ b/.github/release-drafter-seccomp-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "seccomp-psp-policy/v$RESOLVED_VERSION"
 tag-template: "seccomp-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: seccomp-psp-policy/v

--- a/.github/release-drafter-selinux-psp-policy.yml
+++ b/.github/release-drafter-selinux-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "selinux-psp-policy/v$RESOLVED_VERSION"
 tag-template: "selinux-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: selinux-psp-policy/v

--- a/.github/release-drafter-share-pid-namespace-policy.yml
+++ b/.github/release-drafter-share-pid-namespace-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "share-pid-namespace-policy/v$RESOLVED_VERSION"
 tag-template: "share-pid-namespace-policy/v$RESOLVED_VERSION"
 tag-prefix: share-pid-namespace-policy/v

--- a/.github/release-drafter-sleeping-policy.yml
+++ b/.github/release-drafter-sleeping-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "sleeping-policy/v$RESOLVED_VERSION"
 tag-template: "sleeping-policy/v$RESOLVED_VERSION"
 tag-prefix: sleeping-policy/v

--- a/.github/release-drafter-sysctl-psp-policy.yml
+++ b/.github/release-drafter-sysctl-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "sysctl-psp-policy/v$RESOLVED_VERSION"
 tag-template: "sysctl-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: sysctl-psp-policy/v

--- a/.github/release-drafter-trusted-repos-policy.yml
+++ b/.github/release-drafter-trusted-repos-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "trusted-repos-policy/v$RESOLVED_VERSION"
 tag-template: "trusted-repos-policy/v$RESOLVED_VERSION"
 tag-prefix: trusted-repos-policy/v

--- a/.github/release-drafter-unique-service-selector-policy.yml
+++ b/.github/release-drafter-unique-service-selector-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "unique-service-selector-policy/v$RESOLVED_VERSION"
 tag-template: "unique-service-selector-policy/v$RESOLVED_VERSION"
 tag-prefix: unique-service-selector-policy/v

--- a/.github/release-drafter-user-group-psp-policy.yml
+++ b/.github/release-drafter-user-group-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "user-group-psp-policy/v$RESOLVED_VERSION"
 tag-template: "user-group-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: user-group-psp-policy/v

--- a/.github/release-drafter-verify-image-signatures.yml
+++ b/.github/release-drafter-verify-image-signatures.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "verify-image-signatures/v$RESOLVED_VERSION"
 tag-template: "verify-image-signatures/v$RESOLVED_VERSION"
 tag-prefix: verify-image-signatures/v

--- a/.github/release-drafter-volumeMounts-policy.yml
+++ b/.github/release-drafter-volumeMounts-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "volumeMounts-policy/v$RESOLVED_VERSION"
 tag-template: "volumeMounts-policy/v$RESOLVED_VERSION"
 tag-prefix: volumeMounts-policy/v

--- a/.github/release-drafter-volumes-psp-policy.yml
+++ b/.github/release-drafter-volumes-psp-policy.yml
@@ -1,4 +1,4 @@
-_extends: kubewarden-policies:.github/release-drafter.yml
+_extends: policies:.github/release-drafter.yml
 name-template: "volumes-psp-policy/v$RESOLVED_VERSION"
 tag-template: "volumes-psp-policy/v$RESOLVED_VERSION"
 tag-prefix: volumes-psp-policy/v

--- a/hack/release-drafter-config-generator.go
+++ b/hack/release-drafter-config-generator.go
@@ -6,7 +6,7 @@ import (
 	"text/template"
 )
 
-const fileTemplate = `_extends: kubewarden-policies:.github/release-drafter.yml
+const fileTemplate = `_extends: policies:.github/release-drafter.yml
 name-template: "{{.PolicyName}}/v$RESOLVED_VERSION"
 tag-template: "{{.PolicyName}}/v$RESOLVED_VERSION"
 tag-prefix: {{.PolicyName}}/v


### PR DESCRIPTION
## Description

Fixes a typo the release drafter configuration files. The files have a reference to the POC repository instead of the current repository.


Related to https://github.com/kubewarden/kubewarden-controller/issues/1257
