### PR TITLE
chore(ci): add updatecli script used to trigger release.

### DIFF
--- a/updatecli/updatecli.d/open-release-pr.yaml
+++ b/updatecli/updatecli.d/open-release-pr.yaml
@@ -1,0 +1,87 @@
+# This Updatecli manifest automates opening a pull request to prepare a policy
+# project for release. It checks for required files, updates version
+# information in metadata and Cargo files, and creates a GitHub pull request
+# with appropriate labels and reviewers. The workflow ensures all
+# release-related changes are made and ready for review before publishing.
+name: Open PR that prepares the policy for release
+pipelineid: "{{ .policy.working_dir }}"
+
+conditions:
+  checkCargoTomlExists:
+    name: Check if Cargo.toml exists
+    scmid: "policy-repo"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: "{{ .policy.working_dir }}/Cargo.toml"
+
+targets:
+  updateMetadataAnnotationVersion:
+    name: Update metadata.yml with new version
+    kind: yaml
+    scmid: "policy-repo"
+    disableconditions: true
+    spec:
+      searchpattern: true
+      file: "{{ .policy.working_dir}}/metadata.y*ml"
+      key: "$.annotations.'io.kubewarden.policy.version'"
+      value: "{{ .policy.version }}"
+
+  updateCargoTomlVersion:
+    name: Update Cargo.toml, Cargo.lock with new version
+    scmid: "policy-repo"
+    dependson:
+      - condition#checkCargoTomlExists
+    kind: shell
+    spec:
+      shell: /usr/bin/bash
+      command: "cargo set-version --package {{ .policy.rust_package }} {{ .policy.version }}"
+      workdir: "{{ .policy.working_dir }}"
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - "Cargo.toml"
+            - "../Cargo.lock"
+
+actions:
+  openUpdatePR:
+    title: "build: Prepare for release {{ .policy.working_dir }}"
+    kind: "github/pullrequest"
+    scmid: "policy-repo"
+    spec:
+      mergemethod: squash
+      description: |
+        Bumped versions to prepare for a release with version `{{ .policy.working_dir }}`.
+
+        > [!NOTE]
+        > Merging this PR will trigger a release of this policy.
+      #     {{ if .pr.reviewrs }}
+      reviewers:
+        #           {{ range .pr.reviewers }}
+        - "{{ . }}"
+      #           {{ end }}
+      #     {{ end }}
+      #     {{ if .pr.labels }}
+      labels:
+        #           {{ range .pr.labels }}
+        - "{{ . }}"
+#           {{ end }}
+#     {{ end }}
+
+scms:
+  policy-repo:
+    kind: github
+    spec:
+      user: "{{ .github.git_author }}"
+      email: "{{ .github.git_email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repo }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.owner }}"
+      branch: "{{ .github.branch }}"
+      commitusingapi: true # enable cryptographically signed commits
+      commitmessage:
+        type: "build"
+        hidecredit: true
+        footers: "Signed-off-by: {{ .github.git_author }} <{{ .github.git_email }}>"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,19 @@
+---
+# Values.yaml contains settings that be used from Updatecli manifest.
+
+# pipelineid: release_pr # branch will be named: updatecli_main_release_pr
+
+github:
+  branch: "main"
+  git_author: "Kubewarden bot"
+  git_email: "cncf-kubewarden-maintainers@lists.cncf.io"
+  token: "UPDATECLI_GITHUB_TOKEN"
+
+# pr contains the pull request settings that can be overridden
+pr:
+  labels:
+    - "TRIGGER-RELEASE"
+    - "kind/chore"
+    - "area/release"
+  reviewers:
+    - "kubewarden/kubewarden-developers"


### PR DESCRIPTION
## Description

Adds the updatecli script used to create the policy release PR.

Related to https://github.com/kubewarden/kubewarden-controller/issues/1257
