### PR TITLE
chore(artifacthub): add repository ID.

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,5 +1,5 @@
 ---
-repositoryID: <PUT YOUR ARTIFACTHUB REPO ID HERE>
+repositoryID: 7df62717-fa4a-44e3-a884-d293279e8e8c
 owners:
   - name: Kubewarden developers
     email: cncf-kubewarden-maintainers@lists.cncf.io


### PR DESCRIPTION
## Description

Adds the artifacthub repository ID in the artifacthub-repo.yml file.

Related to https://github.com/kubewarden/kubewarden-controller/issues/1257

