### PR TITLE
fix(renovate): disable updates for kyverno-dsl-policy.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,9 @@
     "enabled": true,
     "automerge": true
   },
+  "ignorePaths": [
+    "policies/kyverno-dsl-policy/go.mod"
+  ],
   "packageRules": [
     {
       "description": "bundle dependencies updates together",


### PR DESCRIPTION
## Description

The kyverno-dsl-policy policy should update its packages together with Kyverno. This requires manual work. Therefore, this commit disable the packages updates while the automatic Kyverno update is not possible.

This disable the Kyverno DSL policy updates witch fixes the CI issues [here](https://github.com/kubewarden/policies/pull/81)
