### PR TITLE
ci: Skip artifacthub job if policy lacks AH metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,13 @@ jobs:
           echo "policy_working_dir=$policy_working_dir" >> $GITHUB_OUTPUT
           echo "policy_version=$( echo ${{ github.ref_name }} | sed 's/\(.*\)\/\(.*\)$/\2/' | cut -c2- )" >> $GITHUB_OUTPUT
 
+          # Check for ArtifactHub metadata, to skip if none
+          if yq -e '.annotations."io.artifacthub.displayName"' $policy_working_dir/metadata.yml >/dev/null; then
+            echo "has_artifacthub_metadata=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_artifacthub_metadata=false" >> $GITHUB_OUTPUT
+          fi
+
   ci:
     uses: ./.github/workflows/reusable-ci.yaml
     needs: calculate-policy-from-tag
@@ -213,6 +220,7 @@ jobs:
             });
 
   push-artifacthub:
+    if: needs.calculate-policy-from-tag.outputs.has-artifacthub-metadata == 'true'
     needs: [calculate-policy-from-tag, release]
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the


### PR DESCRIPTION
## Description

there's several policies that we migrated to the monorepo that were not published on artifacthub on purpose (`raw-validation-wasi-policy`, etc).

The push to the artifacthub branch will fail as they lack the proper metadata, so they will not get published but the release workflow will fail in the last step. They will fail with:
```console
$ kwctl scaffold artifacthub --output artifacthub-pkg.yml
Error: policy metadata must specify "io.artifacthub.displayName" in annotations
retcode 1
```

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested locally, untested on CI.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
