### PR TITLE
ci: Retry pull fast forward + push for push-artifacthub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,7 +274,17 @@ jobs:
           VERSION=$(sed --posix -n 's,^version: \(.*\),\1,p' ${{ needs.calculate-policy-from-tag.outputs.policy-working-dir }}/artifacthub-pkg.yml)
           git commit -m "Bump ArtifactHub files for ${{ needs.calculate-policy-from-tag.outputs.policy-working-dir }}, version $VERSION"
 
-          git push origin artifacthub
+          # push can fail as several release jobs run simultaneuously and there's new changes.
+          # Retry in loop with pull fast-forward:
+          for i in {1..5}; do
+            git pull --ff-only origin artifacthub
+            if git push origin artifacthub; then
+              break
+            else
+              echo "Push failed, retrying in 5s..."
+              sleep 5
+            fi
+          done
 
   release-catalog:
     needs: [calculate-policy-from-tag, release]


### PR DESCRIPTION
## Description

When triggering release jobs, sometimes the jobs of several policies try to push to artifacthub branch at the same time, failing with:
        "Updates were rejected because the remote contains work that you do not
        have locally"

Do a pull fast-forward and retry the push.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
