### PR TITLE
fix: update git files change detection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
             # list only changes of files in `policies/`:
             # it's necessary to add the `|| true` in the pipe because if the CI is running in a PR with no changes under
             # the policies directory, the script will fail in the grep command.
-            git_files="$(git diff --no-color --find-renames --find-copies --name-only origin/${{ github.base_ref }} ${{ github.sha }} -- policies | grep -v '^policies/crates/' || true)"
+            git_files="$(git diff --no-color --find-renames --find-copies --name-only origin/${{ github.base_ref }}...${{ github.sha }} -- policies | grep -v '^policies/crates/' || true)"
 
             # build policy_working_dirs:
             policies_working_dirs=($(echo "$git_files" | cut -d/ -f1,2 ))


### PR DESCRIPTION
## Description

Without three dots git diff shows also changes merged upstream:
- origin/main HEAD -> Includes their changes and yours
-  origin/main...HEAD -> Includes only your changes

It can be fixed by manually rebasing to upstream/main or using `...` in git diff.

Fix for https://github.com/kubewarden/policies/actions/runs/21147377354/workflow?pr=156
Tested with https://github.com/kubewarden/policies/pull/156:

```bash
# this lists files changed also upstream
~ git diff --no-color --find-renames --find-copies --name-only origin/main HEAD -- policies | grep -v '^policies/crates/'
policies/Cargo.lock
policies/Cargo.toml
policies/allow-privilege-escalation-psp-policy/Cargo.toml
policies/allow-privilege-escalation-psp-policy/metadata.yml
policies/allowed-proc-mount-types-psp-policy/metadata.yml
policies/annotations-policy/Cargo.toml
policies/annotations-policy/metadata.yml
policies/apparmor-psp-policy/Cargo.toml
policies/apparmor-psp-policy/metadata.yml
policies/cel-policy/go.mod
policies/cel-policy/metadata.yml
policies/container-resources-policy/go.mod
...
...

# this ignores changes upstream
~ git diff --no-color --find-renames --find-copies --name-only origin/main...HEAD -- policies | grep -v '^policies/crates/'
policies/deprecated-api-versions-policy/e2e.bats
policies/deprecated-api-versions-policy/test_data/deprecated_ingress.json
policies/deprecated-api-versions-policy/test_data/valid_ingress.json
```