### PR TITLE
chore(ci): policy-catalog requires updated artifacthub files.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,7 @@ jobs:
           kwctl scaffold artifacthub --output ${{ runner.temp }}/artifacthub-pkg.yml
 
       - name: Push up-to-date artifacthub-pkg.yml
+        id: artifacthub-push
         shell: bash
         run: |
           set -x
@@ -287,7 +288,7 @@ jobs:
           done
 
   release-catalog:
-    needs: [calculate-policy-from-tag, release]
+    needs: [calculate-policy-from-tag, release, artifacthub-push]
     uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-catalog.yml@247608f0b5a1562a6fd2576e5b2e6cbe62551baf # v4.5.15
     with:
       policy-name: ${{ needs.calculate-policy-from-tag.outputs.policy-name }}


### PR DESCRIPTION

## Description

Updates the release.yml CI setting the artifacthub files update a requirement to trigger the policy-catalog updates. Othewise, the policy-catalog can fetch old artifacthub files.


