### PR TITLE
chore: remove artifacthub-repo.yml from old repositories.

### DIFF
--- a/policies/allow-privilege-escalation-psp-policy/artifacthub-repo.yml
+++ b/policies/allow-privilege-escalation-psp-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 94744634-6809-4927-9f7d-da9d571408d3
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/allowed-fsgroups-psp-policy/artifacthub-repo.yml
+++ b/policies/allowed-fsgroups-psp-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 3eb9347f-3096-4187-8958-015b5b8a6fde
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/allowed-proc-mount-types-psp-policy/artifacthub-repo.yml
+++ b/policies/allowed-proc-mount-types-psp-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 9b69ea52-f292-4634-83e6-f46bcc4bf573
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/annotations-policy/artifacthub-repo.yml
+++ b/policies/annotations-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: b20bf183-25f6-43e3-b0b9-6c3989e9b433
-owners:
-  - name: Kubewarden developers
-    email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/apparmor-psp-policy/artifacthub-repo.yml
+++ b/policies/apparmor-psp-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 447dd528-5d0c-4c2e-9e36-11d68135fb3a
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/capabilities-psp-policy/artifacthub-repo.yml
+++ b/policies/capabilities-psp-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: c1f1740c-8cc9-48b0-bc1b-4dd17021ae57
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/deprecated-api-versions-policy/artifacthub-repo.yml
+++ b/policies/deprecated-api-versions-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 42c39ebd-5522-4947-8f3e-5f1f13a3f761
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/do-not-expose-admission-controller-webhook-services-policy/artifacthub-repo.yml
+++ b/policies/do-not-expose-admission-controller-webhook-services-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: d448a68b-831f-429e-8f50-4c03631e7321
-owners:
-  - name: Kubewarden developers
-    email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/echo/artifacthub-repo.yml
+++ b/policies/echo/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 674dca07-53b0-4276-9d10-34be384b0175
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/env-variable-secrets-scanner-policy/artifacthub-repo.yml
+++ b/policies/env-variable-secrets-scanner-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 0eb4bb18-a872-4852-9f41-0500b5829f33
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/environment-variable-policy/artifacthub-repo.yml
+++ b/policies/environment-variable-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 8008dd14-3c2c-4328-b31b-aed07b65a2b3
-owners:
-  - name: Kubewarden developers
-    email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/flexvolume-drivers-psp-policy/artifacthub-repo.yml
+++ b/policies/flexvolume-drivers-psp-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: f38c5657-ea61-45d4-b972-ef643aa4123a
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/host-namespaces-psp-policy/artifacthub-repo.yml
+++ b/policies/host-namespaces-psp-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: fd84242f-a144-48d8-8711-bf16b7f45e0c
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/image-cve-policy/artifacthub-repo.yml
+++ b/policies/image-cve-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 5221cb46-617a-4003-ac70-4a6da44a75eb
-owners:
-  - name: Kubewarden developers
-    email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/labels-policy/artifacthub-repo.yml
+++ b/policies/labels-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 6fe97a3b-0613-44d5-a857-c73857e9d359
-owners:
-  - name: Kubewarden developers
-    email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/persistentvolumeclaim-storageclass-policy/artifacthub-repo.yml
+++ b/policies/persistentvolumeclaim-storageclass-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: f4813654-d8c4-465f-9538-d7e4c08e7499
-owners:
-  - name: Kubewarden developers
-    email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/pod-ndots-policy/artifacthub-repo.yml
+++ b/policies/pod-ndots-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 37cb90f5-171c-44a7-957f-502748455e57
-owners:
-  - name: Kubewarden developers
-    email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/pod-privileged-policy/artifacthub-repo.yml
+++ b/policies/pod-privileged-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: daad9d04-ca4a-42af-a41a-6617cf5e5cc5
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/pod-runtime-class-policy/artifacthub-repo.yml
+++ b/policies/pod-runtime-class-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: bbbec0ec-338c-49f4-b71e-91ed5f7532b5
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/priority-class-policy/artifacthub-repo.yml
+++ b/policies/priority-class-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 57535f2e-d5d3-4032-8dbd-78c81e82c406
-owners:
-  - name: Kubewarden developers
-    email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/probes-policy/artifacthub-repo.yml
+++ b/policies/probes-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 90cf8d96-be95-4554-be51-1e9829dca853
-owners:
-  - name: Kubewarden developers
-    email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/psa-label-enforcer-policy/artifacthub-repo.yml
+++ b/policies/psa-label-enforcer-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 3e781b2b-b407-4b03-9c1f-8c4d9170a118
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/readonly-root-filesystem-psp-policy/artifacthub-repo.yml
+++ b/policies/readonly-root-filesystem-psp-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 1f812d9e-ca97-4635-99b4-ef187ca02c3e
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/seccomp-psp-policy/artifacthub-repo.yml
+++ b/policies/seccomp-psp-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 50084185-f8cc-4df5-a19e-a4191972cc16
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/selinux-psp-policy/artifacthub-repo.yml
+++ b/policies/selinux-psp-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 45489a01-b4c9-4d6e-b9a3-92f246c30cf9
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/share-pid-namespace-policy/artifacthub-repo.yml
+++ b/policies/share-pid-namespace-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: e212bed3-e500-4803-ae64-cedee6b75bda
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/trusted-repos-policy/artifacthub-repo.yml
+++ b/policies/trusted-repos-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 64f7e754-4716-487d-942b-c4d3901c97d2
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/unique-service-selector-policy/artifacthub-repo.yml
+++ b/policies/unique-service-selector-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 029ca434-1676-4493-8137-068674de0fcf
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/user-group-psp-policy/artifacthub-repo.yml
+++ b/policies/user-group-psp-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 6117d439-f683-4013-b8d6-6185178f4fde
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/verify-image-signatures/artifacthub-repo.yml
+++ b/policies/verify-image-signatures/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: 0c593e65-f235-4c88-ac98-beda69fdd847
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io

--- a/policies/volumeMounts-policy/artifacthub-repo.yml
+++ b/policies/volumeMounts-policy/artifacthub-repo.yml
@@ -1,5 +1,0 @@
----
-repositoryID: e5e01d90-329b-44e5-b173-b4a6a7f3a3bc
-owners:
-- name: Kubewarden developers
-  email: cncf-kubewarden-maintainers@lists.cncf.io


### PR DESCRIPTION
## Description

Removes the artifacthub-repo.yml imported from old policies repositories. They are not need anymore.

Related to https://github.com/kubewarden/kubewarden-controller/issues/1251
