### PR TITLE
fix(ci): missing cosign v2 signature.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,14 @@ jobs:
           IMMUTABLE_REF=$(kwctl push -o json annotated-policy.wasm ghcr.io/${{ github.repository_owner }}/policies/${{ needs.calculate-policy-from-tag.outputs.policy-id }}:latest | jq -r .immutable_ref)
 
           echo Keyless signing of policy using cosign
-          cosign sign --yes ${IMMUTABLE_REF}
+
+          # We need to disable the new bundle format enabled by default since 
+          # cosign v3.x.x because some verification tools (e.g. slsactl) are not
+          # able to properly verify the signatures using this new format
+          cosign sign --yes --new-bundle-format=false --use-signing-config=false ${IMMUTABLE_REF}
+
+          # Sign also with cosign v3 signature format
+          cosign sign --yes --new-bundle-format=true --use-signing-config=true ${IMMUTABLE_REF}
 
       - name: Publish Wasm policy artifact to OCI registry with the version tag and 'latest'
         shell: bash
@@ -156,7 +163,14 @@ jobs:
           IMMUTABLE_REF=$(kwctl push -o json annotated-policy.wasm ghcr.io/${{ github.repository_owner }}/policies/${{ needs.calculate-policy-from-tag.outputs.policy-id }}:${OCI_TAG} | jq -r .immutable_ref)
 
           echo Keyless signing of policy using cosign
-          cosign sign --yes ${IMMUTABLE_REF}
+
+          # We need to disable the new bundle format enabled by default since 
+          # cosign v3.x.x because some verification tools (e.g. slsactl) are not
+          # able to properly verify the signatures using this new format
+          cosign sign --yes --new-bundle-format=false --use-signing-config=false ${IMMUTABLE_REF}
+
+          # Sign also with cosign v3 signature format
+          cosign sign --yes --new-bundle-format=true --use-signing-config=true ${IMMUTABLE_REF}
 
       - name: Create release
         id: create-release


### PR DESCRIPTION
## Description

Adds an additional signing step in the release CI to create cosign v2 signature. This is required by some tools to verify the policies as well as to ArtifactHub.

Fix https://github.com/kubewarden/policies/issues/246

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Tested in my fork:

<img width="1556" height="866" alt="image" src="https://github.com/user-attachments/assets/e6c30a1d-1bc5-40bb-886b-017f2ded075c" />
