### PR TITLE
fix(ci): fix policy wasm binary link.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,6 +257,18 @@ jobs:
         run: |
           kwctl scaffold artifacthub --output ${{ runner.temp }}/artifacthub-pkg.yml
 
+      # Currently, kwctl is not able to handle policies from monorepos. Therefore,
+      # the links to the wasm binary does not consider the policy subdirectory.
+      # Therefore, until the kwctl is updated we need to fix the link manually.
+      - name: Fix policy.wasm link
+        shell: bash
+        working-directory: ${{ needs.calculate-policy-from-tag.outputs.policy-working-dir }}
+        run: |
+          # Capture the current directory name
+          export DIR_NAME=$(basename "$PWD")
+          # Update the URL by inserting the directory name followed by a slash
+          yq -i '(.links[] | select(.name == "policy")).url |= sub("/v", "/" + env(DIR_NAME) + "/v")' ${{ runner.temp }}/artifacthub-pkg.yml
+
       - name: Push up-to-date artifacthub-pkg.yml
         id: artifacthub-push
         shell: bash


### PR DESCRIPTION
## Description 

Currently, kwctl is not able to handle policies from monorepos. Therefore, the links to the wasm binary does not consider the policy subdirectory. Therefore, until the kwctl is updated we need to fix the link manually. This commit adds an additional step that fix the link in the artifacthub-pkg.yml file generate by kwctl.

This issue was reported by @kravciak. Thanks!

Related to https://github.com/kubewarden/kubewarden-controller/issues/1251

## Test

I've test a release in my fork:

https://github.com/jvanz/policies/blob/d89efc32b2c9cce1bcd46af023fc38426be8e2a4/policies/environment-variable-policy/artifacthub-pkg.yml#L30
