### PR TITLE
fix(image-cve-policy): fix field selector

### DIFF
--- a/policies/image-cve-policy/src/lib.rs
+++ b/policies/image-cve-policy/src/lib.rs
@@ -372,7 +372,7 @@ fn get_vulnerability_report_by_tag(
             namespace: namespace.to_string(),
             label_selector: None,
             field_selector: Some(format!(
-                "imageMetadata.repository={},imageMetadata.tag={},platform={}",
+                "imageMetadata.repository={},imageMetadata.tag={},imageMetadata.platform={}",
                 repository, tag, platform_sbomscanner
             )),
         }) {
@@ -1243,7 +1243,7 @@ mod tests {
                         let expected_fields = vec![
                             format!("imageMetadata.repository={}", "library/nginx"),
                             format!("imageMetadata.tag={}", "1.27.1"),
-                            format!("platform={}", "linux/amd64"),
+                            format!("imageMetadata.platform={}", "linux/amd64"),
                         ];
                         for expected in expected_fields {
                             if !fields.contains(&expected) {


### PR DESCRIPTION
When looking for a VulnerabilityReport by tag, the `platform` field selector must be defined as `imageMetadata.platform`.
