### PR TITLE
chore(ci): remove pull_request_target trigger.

### DIFF
--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -5,9 +5,6 @@ on:
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize, edited]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Following orientations from the SUSE security team, this commit removes the pull_request_target trigger from CI.

