### PR TITLE
fix: remove cosign v2 double-signing, use v3 bundle format only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,14 +142,7 @@ jobs:
           IMMUTABLE_REF=$(kwctl push -o json annotated-policy.wasm ghcr.io/${{ github.repository_owner }}/policies/${{ needs.calculate-policy-from-tag.outputs.policy-id }}:latest | jq -r .immutable_ref)
 
           echo Keyless signing of policy using cosign
-
-          # We need to disable the new bundle format enabled by default since 
-          # cosign v3.x.x because some verification tools (e.g. slsactl) are not
-          # able to properly verify the signatures using this new format
-          cosign sign --yes --new-bundle-format=false --use-signing-config=false ${IMMUTABLE_REF}
-
-          # Sign also with cosign v3 signature format
-          cosign sign --yes --new-bundle-format=true --use-signing-config=true ${IMMUTABLE_REF}
+          cosign sign --yes ${IMMUTABLE_REF}
 
       - name: Publish Wasm policy artifact to OCI registry with the version tag and 'latest'
         shell: bash
@@ -163,14 +156,7 @@ jobs:
           IMMUTABLE_REF=$(kwctl push -o json annotated-policy.wasm ghcr.io/${{ github.repository_owner }}/policies/${{ needs.calculate-policy-from-tag.outputs.policy-id }}:${OCI_TAG} | jq -r .immutable_ref)
 
           echo Keyless signing of policy using cosign
-
-          # We need to disable the new bundle format enabled by default since 
-          # cosign v3.x.x because some verification tools (e.g. slsactl) are not
-          # able to properly verify the signatures using this new format
-          cosign sign --yes --new-bundle-format=false --use-signing-config=false ${IMMUTABLE_REF}
-
-          # Sign also with cosign v3 signature format
-          cosign sign --yes --new-bundle-format=true --use-signing-config=true ${IMMUTABLE_REF}
+          cosign sign --yes ${IMMUTABLE_REF}
 
       - name: Create release
         id: create-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,8 +141,8 @@ jobs:
           echo Pushing :latest policy to OCI container registry
           IMMUTABLE_REF=$(kwctl push -o json annotated-policy.wasm ghcr.io/${{ github.repository_owner }}/policies/${{ needs.calculate-policy-from-tag.outputs.policy-id }}:latest | jq -r .immutable_ref)
 
-          echo Keyless signing of policy using cosign
-          cosign sign --yes ${IMMUTABLE_REF}
+          echo Keyless signing of policy using cosign v2 format
+          cosign sign --yes --new-bundle-format=false --use-signing-config=false ${IMMUTABLE_REF}
 
       - name: Publish Wasm policy artifact to OCI registry with the version tag and 'latest'
         shell: bash
@@ -155,8 +155,8 @@ jobs:
           echo Pushing tagged policy to OCI container registry
           IMMUTABLE_REF=$(kwctl push -o json annotated-policy.wasm ghcr.io/${{ github.repository_owner }}/policies/${{ needs.calculate-policy-from-tag.outputs.policy-id }}:${OCI_TAG} | jq -r .immutable_ref)
 
-          echo Keyless signing of policy using cosign
-          cosign sign --yes ${IMMUTABLE_REF}
+          echo Keyless signing of policy using cosign v2 format
+          cosign sign --yes --new-bundle-format=false --use-signing-config=false ${IMMUTABLE_REF}
 
       - name: Create release
         id: create-release


### PR DESCRIPTION
## Summary

Removes the legacy cosign v2 double-signing from the release workflow. All known verification tools now support the cosign v3 bundle format, so the compatibility workaround is no longer needed.

## Tools verified

- **ArtifactHub**: confirmed v3 bundle support (see artifacthub/hub#4684, referenced in the issue)
- **slsactl**: already importing `github.com/sigstore/cosign/v3 v3.0.5` in its go.mod
- **hauler**: updated cosign fork to 3.0.4 in its latest release

## Changes

- `.github/workflows/release.yml`: removed v2 signing step from both signing blocks (latest tag push and version tag push), kept single `cosign sign` with v3 defaults

cosign v3 defaults to the bundle format, no explicit flags needed.

Related: kubewarden/github-actions#280
Closes kubewarden/kubewarden-controller#1614