### PR TITLE
ci: add monthly scheduled release for all policies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       policy-id: ${{ steps.calculate-vars.outputs.policy_id }}
       policy-name: ${{ steps.calculate-vars.outputs.policy_name }}
       has-artifacthub-metadata: ${{ steps.calculate-vars.outputs.has_artifacthub_metadata }}
+      skip-publishing: ${{ steps.calculate-vars.outputs.skip_publishing }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: calculate-vars
@@ -47,6 +48,27 @@ jobs:
           else
             echo "has_artifacthub_metadata=false" >> $GITHUB_OUTPUT
           fi
+
+          # Policies that should not be published to ArtifactHub or the policy-catalog.
+          # They still receive a GitHub Release and OCI package.
+          EXCLUDED_FROM_PUBLISHING=(
+            "context-aware-demo"
+            "go-wasi-context-aware-test-policy"
+            "raw-mutation-policy"
+            "raw-mutation-wasi-policy"
+            "raw-validation-opa-policy"
+            "raw-validation-policy"
+            "raw-validation-wasi-policy"
+            "sleeping-policy"
+          )
+          skip_publishing=false
+          for excluded in "${EXCLUDED_FROM_PUBLISHING[@]}"; do
+            if [ "$policy_name" == "$excluded" ]; then
+              skip_publishing=true
+              break
+            fi
+          done
+          echo "skip_publishing=$skip_publishing" >> $GITHUB_OUTPUT
 
   ci:
     uses: ./.github/workflows/reusable-ci.yaml
@@ -233,7 +255,9 @@ jobs:
             });
 
   push-artifacthub:
-    if: needs.calculate-policy-from-tag.outputs.has-artifacthub-metadata == 'true'
+    if: |
+      needs.calculate-policy-from-tag.outputs.has-artifacthub-metadata == 'true' &&
+      needs.calculate-policy-from-tag.outputs.skip-publishing != 'true'
     needs: [calculate-policy-from-tag, release]
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the
@@ -300,18 +324,21 @@ jobs:
           git commit -m "Bump ArtifactHub files for ${{ needs.calculate-policy-from-tag.outputs.policy-working-dir }}, version $VERSION"
 
           # push can fail as several release jobs run simultaneuously and there's new changes.
-          # Retry in loop with pull fast-forward:
+          # Retry in loop with rebase to replay our commit on top of any concurrent pushes:
           for i in {1..5}; do
-            git pull --ff-only origin artifacthub
+            git pull --rebase origin artifacthub
             if git push origin artifacthub; then
               break
             else
               echo "Push failed, retrying in 5s..."
               sleep 5
             fi
-          done
+          done || { echo "Failed to push to artifacthub branch after 5 retries"; exit 1; }
 
   release-catalog:
+    if: |
+      github.repository_owner == 'kubewarden' &&
+      needs.calculate-policy-from-tag.outputs.skip-publishing != 'true'
     needs: [calculate-policy-from-tag, release, push-artifacthub]
     uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-catalog.yml@0f1672d63bd3572f204917d68390d87f7430069a # v5.0.0
     with:

--- a/.github/workflows/trigger-policy-release.yaml
+++ b/.github/workflows/trigger-policy-release.yaml
@@ -1,4 +1,6 @@
 on:
+  schedule:
+    - cron: "30 3 12 * *" # At 03:30 on day-of-month 12
   workflow_dispatch:
     inputs:
       policy-working-dir:
@@ -33,9 +35,14 @@ jobs:
         shell: bash
         run: |
           if [ -z "${{inputs.policy-working-dir}}" ]; then
-            # All policies must be released
+            # All policies must be released (scheduled run or workflow_dispatch with no specific policy)
             git remote -v
             policies_working_dirs=($(find policies -maxdepth 2 -name Makefile -exec dirname '{}' \;))
+
+            declare -p policies_working_dirs # for debug
+            policy_working_dirs=$(jq --compact-output --null-input \
+              '$ARGS.positional | unique' \
+              --args -- "${policies_working_dirs[@]}")
           else
             policy_working_dir=policies/${{ inputs.policy-working-dir }}
             if [ ! -d "$policy_working_dir" ]; then
@@ -43,12 +50,13 @@ jobs:
               echo "::error title=Invalid inputs::$policy_working_dir does not exist"
               exit 1;
             fi
-            # Release a single policy
+            # Release a single policy 
             policies_working_dirs=("policies/${{ inputs.policy-working-dir }}")
+            declare -p policies_working_dirs # for debug
+            policy_working_dirs=$(jq --compact-output --null-input '$ARGS.positional | unique' --args -- "${policies_working_dirs[@]}")
           fi
 
-          declare -p policies_working_dirs # for debug
-          policy_working_dirs=$(jq --compact-output --null-input '$ARGS.positional | unique' --args -- "${policies_working_dirs[@]}")
+          echo "policy_working_dirs=$policy_working_dirs"
           echo "policy_working_dirs=$policy_working_dirs" >> $GITHUB_OUTPUT
 
   open-release-pr:
@@ -56,6 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-policy-matrix
     strategy:
+      fail-fast: false
+      # limit the number of jobs to avoid rate limits errors from Github API
+      max-parallel: 5
       matrix:
         policy-working-dir: ${{ fromJSON(needs.calculate-policy-matrix.outputs.policy_working_dirs) }}
     steps:


### PR DESCRIPTION
## Description

Add a monthly schedule trigger to trigger-policy-release.yaml. This trigger will open a PRs to release all policies using the version generated by Release Drafter. Additionally, it includes checks to ensure specific policies are excluded from ArtifactHub as intended, as well as a gate to prevent policy-catalog publishing from forks.

Fix #397 
