### PR TITLE
Serialize ArtifactHub branch updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,6 +265,9 @@ jobs:
       # added or changed files to the repository.
       contents: write
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-artifacthub
+      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -324,8 +327,9 @@ jobs:
           VERSION=$(sed --posix -n 's,^version: \(.*\),\1,p' ${{ needs.calculate-policy-from-tag.outputs.policy-working-dir }}/artifacthub-pkg.yml)
           git commit -m "Bump ArtifactHub files for ${{ needs.calculate-policy-from-tag.outputs.policy-working-dir }}, version $VERSION"
 
-          # push can fail as several release jobs run simultaneuously and there's new changes.
-          # Retry in loop with rebase to replay our commit on top of any concurrent pushes:
+          # The ArtifactHub branch is updated by many release runs. The job
+          # concurrency group serializes normal releases; keep the rebase retry
+          # for any out-of-band branch update that lands while this job runs.
           for i in {1..5}; do
             git pull --rebase origin artifacthub
             if git push origin artifacthub; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-artifacthub
+      group: artifacthub-branch-updates
       cancel-in-progress: false
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- queue the `push-artifacthub` job with a workflow-level ArtifactHub concurrency group
- keep the existing rebase retry for out-of-band branch updates while avoiding normal release races

Fixes #366

## Testing

- `yq e . .github/workflows/release.yml >/dev/null`
- `git diff --check`

`actionlint` is not installed in my local environment.