### PR TITLE
fix: add GitHub release tag annotation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,18 +280,6 @@ jobs:
         run: |
           kwctl scaffold artifacthub --output ${{ runner.temp }}/artifacthub-pkg.yml
 
-      # Currently, kwctl is not able to handle policies from monorepos. Therefore,
-      # the links to the wasm binary does not consider the policy subdirectory.
-      # Therefore, until the kwctl is updated we need to fix the link manually.
-      - name: Fix policy.wasm link
-        shell: bash
-        working-directory: ${{ needs.calculate-policy-from-tag.outputs.policy-working-dir }}
-        run: |
-          # Capture the current directory name
-          export DIR_NAME=$(basename "$PWD")
-          # Update the URL by inserting the directory name followed by a slash
-          yq -i '(.links[] | select(.name == "policy")).url |= sub("/v", "/" + env(DIR_NAME) + "/v")' ${{ runner.temp }}/artifacthub-pkg.yml
-
       - name: Push up-to-date artifacthub-pkg.yml
         id: artifacthub-push
         shell: bash

--- a/.github/workflows/trigger-policy-release.yaml
+++ b/.github/workflows/trigger-policy-release.yaml
@@ -155,6 +155,7 @@ jobs:
             version: "${{ steps.create-release.outputs.resolved_version}}"
             working_dir: "${{ matrix.policy-working-dir }}"
             rust_package: "${{ steps.policy-info.outputs.policy-rust-package }}"
+            basename: "${{ steps.policy-info.outputs.policy-basename }}"
           EOF
 
       - name: Open PR with updatecli

--- a/policies/allow-privilege-escalation-psp-policy/metadata.yml
+++ b/policies/allow-privilege-escalation-psp-policy/metadata.yml
@@ -58,3 +58,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.severity: medium
   io.kubewarden.policy.category: PSP
+  com.github.release.tag: allow-privilege-escalation-psp-policy/v1.0.10

--- a/policies/allowed-fsgroups-psp-policy/metadata.yml
+++ b/policies/allowed-fsgroups-psp-policy/metadata.yml
@@ -27,3 +27,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.severity: medium
   io.kubewarden.policy.category: PSP
+  com.github.release.tag: allowed-fsgroups-psp-policy/v1.0.9

--- a/policies/allowed-proc-mount-types-psp-policy/metadata.yml
+++ b/policies/allowed-proc-mount-types-psp-policy/metadata.yml
@@ -27,3 +27,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.severity: medium
   io.kubewarden.policy.category: PSP
+  com.github.release.tag: allowed-proc-mount-types-psp-policy/v1.0.12

--- a/policies/annotations-policy/metadata.yml
+++ b/policies/annotations-policy/metadata.yml
@@ -58,3 +58,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Resource validation
   io.kubewarden.policy.severity: low
+  com.github.release.tag: annotations-policy/v0.1.8

--- a/policies/apparmor-psp-policy/metadata.yml
+++ b/policies/apparmor-psp-policy/metadata.yml
@@ -26,3 +26,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: PSP
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: apparmor-psp-policy/v1.0.11

--- a/policies/capabilities-psp-policy/metadata.yml
+++ b/policies/capabilities-psp-policy/metadata.yml
@@ -55,3 +55,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: PSP
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: capabilities-psp-policy/v1.0.10

--- a/policies/cel-policy/metadata.yml
+++ b/policies/cel-policy/metadata.yml
@@ -38,3 +38,5 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   # io.kubewarden.policy.category: CEL metapolicy
   # io.kubewarden.policy.severity: medium # one of info, low, medium, high, critical. See docs.
+
+  com.github.release.tag: cel-policy/v1.6.0

--- a/policies/container-resources-policy/metadata.yml
+++ b/policies/container-resources-policy/metadata.yml
@@ -66,3 +66,4 @@ annotations:
   # Category indicates policy category. See more here at docs.kubewarden.io
   io.kubewarden.policy.severity: medium # one of info, low, medium, high, critical. See docs.
   io.kubewarden.policy.category: Resource validation
+  com.github.release.tag: container-resources-policy/v1.3.3

--- a/policies/deprecated-api-versions-policy/metadata.yml
+++ b/policies/deprecated-api-versions-policy/metadata.yml
@@ -186,3 +186,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Kubernetes API Versions
   io.kubewarden.policy.severity: low
+  com.github.release.tag: deprecated-api-versions-policy/v1.0.8

--- a/policies/disallow-service-loadbalancer-policy/metadata.yml
+++ b/policies/disallow-service-loadbalancer-policy/metadata.yml
@@ -27,3 +27,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Service
   io.kubewarden.policy.severity: high
+  com.github.release.tag: disallow-service-loadbalancer-policy/v1.0.11

--- a/policies/disallow-service-nodeport-policy/metadata.yml
+++ b/policies/disallow-service-nodeport-policy/metadata.yml
@@ -27,3 +27,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Service
   io.kubewarden.policy.severity: high
+  com.github.release.tag: disallow-service-nodeport-policy/v0.1.11

--- a/policies/do-not-expose-admission-controller-webhook-services-policy/metadata.yml
+++ b/policies/do-not-expose-admission-controller-webhook-services-policy/metadata.yml
@@ -36,3 +36,4 @@ annotations:
   # Category indicates policy category. See more here at docs.kubewarden.io
   io.kubewarden.policy.severity: medium
   io.kubewarden.policy.category: Resource validation
+  com.github.release.tag: do-not-expose-admission-controller-webhook-services-policy/v1.1.5

--- a/policies/echo/metadata.yml
+++ b/policies/echo/metadata.yml
@@ -30,3 +30,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Debug
   io.kubewarden.policy.severity: info
+  com.github.release.tag: echo/v0.1.16

--- a/policies/env-variable-secrets-scanner-policy/metadata.yml
+++ b/policies/env-variable-secrets-scanner-policy/metadata.yml
@@ -58,3 +58,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Secrets
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: env-variable-secrets-scanner-policy/v1.0.12

--- a/policies/environment-variable-policy/metadata.yml
+++ b/policies/environment-variable-policy/metadata.yml
@@ -58,3 +58,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Resource validation
   io.kubewarden.policy.severity: low
+  com.github.release.tag: environment-variable-policy/v3.0.5

--- a/policies/flexvolume-drivers-psp-policy/metadata.yml
+++ b/policies/flexvolume-drivers-psp-policy/metadata.yml
@@ -27,3 +27,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: PSP
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: flexvolume-drivers-psp-policy/v1.0.14

--- a/policies/high-risk-service-account-policy/metadata.yml
+++ b/policies/high-risk-service-account-policy/metadata.yml
@@ -68,3 +68,4 @@ annotations:
   # Category indicates policy category. See more here at docs.kubewarden.io
   io.kubewarden.policy.severity: medium
   io.kubewarden.policy.category: Resource validation
+  com.github.release.tag: high-risk-service-account-policy/v0.1.6

--- a/policies/host-namespaces-psp-policy/metadata.yml
+++ b/policies/host-namespaces-psp-policy/metadata.yml
@@ -57,3 +57,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: PSP
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: host-namespaces-psp-policy/v1.1.8

--- a/policies/hostpaths-psp-policy/metadata.yml
+++ b/policies/hostpaths-psp-policy/metadata.yml
@@ -57,3 +57,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: PSP
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: hostpaths-psp-policy/v1.1.7

--- a/policies/image-cve-policy/metadata.yml
+++ b/policies/image-cve-policy/metadata.yml
@@ -72,3 +72,4 @@ annotations:
   # Category indicates policy category. See more here at docs.kubewarden.io
   io.kubewarden.policy.severity: high
   io.kubewarden.policy.category: Resource validation
+  com.github.release.tag: image-cve-policy/v0.6.0

--- a/policies/ingress-policy/metadata.yml
+++ b/policies/ingress-policy/metadata.yml
@@ -26,3 +26,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Ingress
   io.kubewarden.policy.severity: high
+  com.github.release.tag: ingress-policy/v1.0.8

--- a/policies/kyverno-dsl-policy/metadata.yml
+++ b/policies/kyverno-dsl-policy/metadata.yml
@@ -18,3 +18,4 @@ annotations:
   io.kubewarden.policy.url: https://github.com/kubewarden/policies
   io.kubewarden.policy.source: https://github.com/kubewarden/policies
   io.kubewarden.policy.license: Apache-2.0
+  com.github.release.tag: kyverno-dsl-policy/v0.1.8

--- a/policies/labels-policy/metadata.yml
+++ b/policies/labels-policy/metadata.yml
@@ -58,3 +58,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Resource validation
   io.kubewarden.policy.severity: low
+  com.github.release.tag: labels-policy/v0.1.7

--- a/policies/namespace-label-propagator-policy/metadata.yml
+++ b/policies/namespace-label-propagator-policy/metadata.yml
@@ -54,3 +54,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Resources label enforcer
   io.kubewarden.policy.severity: low
+  com.github.release.tag: namespace-label-propagator-policy/v1.0.9

--- a/policies/ns-policyserver-mapper-policy/metadata.yml
+++ b/policies/ns-policyserver-mapper-policy/metadata.yml
@@ -25,15 +25,12 @@ annotations:
   io.kubewarden.policy.title: ns-policyserver-mapper
   io.kubewarden.policy.version: 0.1.0
   io.kubewarden.policy.description: >
-    Mutates AdmissionPolicy and AdmissionPolicyGroup resources to enforce the
-    PolicyServer they run on. The target PolicyServer is read from the
-    `admission.kubewarden.io/policy-server` label of the Namespace where the
-    policy is being created or updated. Requests are rejected when the label
-    is absent, preventing policies from being scheduled on an unintended
-    PolicyServer.
+    Mutates AdmissionPolicy and AdmissionPolicyGroup resources to enforce the PolicyServer they run on. The target PolicyServer is read from the `admission.kubewarden.io/policy-server` label of the Namespace where the policy is being created or updated. Requests are rejected when the label is absent, preventing policies from being scheduled on an unintended PolicyServer.
+
   io.kubewarden.policy.url: https://github.com/kubewarden/policies
   io.kubewarden.policy.source: https://github.com/kubewarden/policies
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: namespace
   io.kubewarden.policy.severity: high
+  com.github.release.tag: ns-policyserver-mapper-policy/v0.1.0

--- a/policies/persistentvolumeclaim-storageclass-policy/metadata.yml
+++ b/policies/persistentvolumeclaim-storageclass-policy/metadata.yml
@@ -30,3 +30,4 @@ annotations:
   # Category indicates policy category. See more here at docs.kubewarden.io
   io.kubewarden.policy.severity: medium
   io.kubewarden.policy.category: Resource validation
+  com.github.release.tag: persistentvolumeclaim-storageclass-policy/v1.1.5

--- a/policies/pod-ndots-policy/metadata.yml
+++ b/policies/pod-ndots-policy/metadata.yml
@@ -30,3 +30,4 @@ annotations:
   # Category indicates policy category. See more here at docs.kubewarden.io
   io.kubewarden.policy.severity: low
   io.kubewarden.policy.category: Resource validation
+  com.github.release.tag: pod-ndots-policy/v1.0.9

--- a/policies/pod-privileged-policy/metadata.yml
+++ b/policies/pod-privileged-policy/metadata.yml
@@ -57,3 +57,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: PSP
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: pod-privileged-policy/v1.0.10

--- a/policies/pod-runtime-class-policy/metadata.yml
+++ b/policies/pod-runtime-class-policy/metadata.yml
@@ -26,3 +26,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Container runtime
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: pod-runtime-class-policy/v1.0.9

--- a/policies/priority-class-policy/metadata.yml
+++ b/policies/priority-class-policy/metadata.yml
@@ -62,3 +62,4 @@ annotations:
   # Category indicates policy category. See more here at docs.kubewarden.io
   io.kubewarden.policy.severity: medium
   io.kubewarden.policy.category: Resource validation
+  com.github.release.tag: priority-class-policy/v1.1.5

--- a/policies/probes-policy/metadata.yml
+++ b/policies/probes-policy/metadata.yml
@@ -16,3 +16,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/probes
   io.kubewarden.policy.version: 1.0.4
+  com.github.release.tag: probes-policy/v1.0.4

--- a/policies/psa-label-enforcer-policy/metadata.yml
+++ b/policies/psa-label-enforcer-policy/metadata.yml
@@ -27,3 +27,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Pod Security
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: psa-label-enforcer-policy/v1.0.11

--- a/policies/rancher-project-propagate-labels/metadata.yml
+++ b/policies/rancher-project-propagate-labels/metadata.yml
@@ -31,3 +31,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Rancher
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: rancher-project-propagate-labels/v0.1.4

--- a/policies/rancher-project-quotas-namespace-validator/metadata.yml
+++ b/policies/rancher-project-quotas-namespace-validator/metadata.yml
@@ -30,3 +30,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Rancher
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: rancher-project-quotas-namespace-validator/v1.0.10

--- a/policies/readonly-root-filesystem-psp-policy/metadata.yml
+++ b/policies/readonly-root-filesystem-psp-policy/metadata.yml
@@ -27,3 +27,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: PSP
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: readonly-root-filesystem-psp-policy/v1.0.10

--- a/policies/safe-annotations-policy/metadata.yml
+++ b/policies/safe-annotations-policy/metadata.yml
@@ -27,3 +27,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Resource validation
   io.kubewarden.policy.severity: low
+  com.github.release.tag: safe-annotations-policy/v1.0.4

--- a/policies/safe-labels-policy/metadata.yml
+++ b/policies/safe-labels-policy/metadata.yml
@@ -27,3 +27,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Resource validation
   io.kubewarden.policy.severity: low
+  com.github.release.tag: safe-labels-policy/v1.0.9

--- a/policies/seccomp-psp-policy/metadata.yml
+++ b/policies/seccomp-psp-policy/metadata.yml
@@ -27,3 +27,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: PSP
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: seccomp-psp-policy/v1.0.12

--- a/policies/selinux-psp-policy/metadata.yml
+++ b/policies/selinux-psp-policy/metadata.yml
@@ -27,3 +27,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: PSP
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: selinux-psp-policy/v1.0.8

--- a/policies/share-pid-namespace-policy/metadata.yml
+++ b/policies/share-pid-namespace-policy/metadata.yml
@@ -66,3 +66,4 @@ annotations:
   # Category indicates policy category. See more here at docs.kubewarden.io
   io.kubewarden.policy.severity: medium
   io.kubewarden.policy.category: Resource validation
+  com.github.release.tag: share-pid-namespace-policy/v1.0.11

--- a/policies/sysctl-psp-policy/metadata.yml
+++ b/policies/sysctl-psp-policy/metadata.yml
@@ -26,3 +26,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: PSP
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: sysctl-psp-policy/v1.0.11

--- a/policies/trusted-repos-policy/metadata.yml
+++ b/policies/trusted-repos-policy/metadata.yml
@@ -33,3 +33,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Secure supply chain
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: trusted-repos-policy/v2.1.0

--- a/policies/unique-ingress-policy/metadata.yml
+++ b/policies/unique-ingress-policy/metadata.yml
@@ -33,3 +33,4 @@ annotations:
   # Category indicates policy category. See more here at docs.kubewarden.io
   io.kubewarden.policy.severity: medium # one of info, low, medium, high, critical. See docs.
   io.kubewarden.policy.category: Resource validation
+  com.github.release.tag: unique-ingress-policy/v1.0.9

--- a/policies/unique-service-selector-policy/metadata.yml
+++ b/policies/unique-service-selector-policy/metadata.yml
@@ -34,3 +34,4 @@ annotations:
   # Category indicates policy category. See more here at docs.kubewarden.io
   io.kubewarden.policy.severity: medium
   io.kubewarden.policy.category: Resource validation
+  com.github.release.tag: unique-service-selector-policy/v1.0.10

--- a/policies/user-group-psp-policy/metadata.yml
+++ b/policies/user-group-psp-policy/metadata.yml
@@ -60,3 +60,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: PSP
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: user-group-psp-policy/v1.1.5

--- a/policies/verify-image-signatures/metadata.yml
+++ b/policies/verify-image-signatures/metadata.yml
@@ -37,3 +37,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Secure supply chain
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: verify-image-signatures/v1.0.8

--- a/policies/volumeMounts-policy/metadata.yml
+++ b/policies/volumeMounts-policy/metadata.yml
@@ -58,3 +58,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Resource validation
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: volumeMounts-policy/v1.0.8

--- a/policies/volumes-psp-policy/metadata.yml
+++ b/policies/volumes-psp-policy/metadata.yml
@@ -26,3 +26,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: PSP
   io.kubewarden.policy.severity: medium
+  com.github.release.tag: volumes-psp-policy/v1.1.7

--- a/updatecli/updatecli.d/open-release-pr.yaml
+++ b/updatecli/updatecli.d/open-release-pr.yaml
@@ -27,6 +27,17 @@ targets:
       key: "$.annotations.'io.kubewarden.policy.version'"
       value: "{{ .policy.version }}"
 
+  updateMetadataAnnotationGithubReleaseTag:
+    name: Update metadata.yml with new GitHub release tag
+    kind: yaml
+    scmid: "policy-repo"
+    disableconditions: true
+    spec:
+      searchpattern: true
+      file: "{{ .policy.working_dir}}/metadata.y*ml"
+      key: "$.annotations.'com.github.release.tag'"
+      value: "{{ .policy.basename }}/v{{ .policy.version }}"
+
   updateCargoTomlVersion:
     name: Update Cargo.toml, Cargo.lock with new version
     scmid: "policy-repo"


### PR DESCRIPTION
## Description

Set `com.github.release.tag` in every policy metadata file using `<policy-name>/v<version>` so artifacthub links resolve monorepo tags. Furthermore, update release automation so version bump PRs also update `com.github.release.tag` using `<policy-name>/v<version>`.

Fix https://github.com/kubewarden/adm-controller/issues/1398

### Test

Example of the PR generated by the automation: https://github.com/jvanz/policies/pull/152/changes
Commit updating the artifacthub after merging the PR: https://github.com/jvanz/policies/commit/497173709f441212bc16b6c41d5d9cf6b88fe08b (it's not updating the version because I already have the version from other tests)

