### PR TITLE
test(verify-image-signatures): Add v3 signature testcases

### DIFF
--- a/policies/verify-image-signatures/e2e.bats
+++ b/policies/verify-image-signatures/e2e.bats
@@ -242,3 +242,38 @@
   [ $(expr "$output" : '.*subject: !equal kubewarden@cncf.io.*') -ne 0 ]
 }
 
+@test "Public key verification with cosign v3 format" {
+  # This test verifies an image signed using cosign v3 (OCI referrers / Sigstore
+  # bundle format) with a public key. The image has ONLY a v3 OCI referrer
+  # signature and no legacy .sig tag, ensuring we test v3 verification
+  # exclusively.
+  #
+  # Need to run the command inside of `bash -c` because of a bats
+  # limitation: https://bats-core.readthedocs.io/en/stable/gotchas.html?highlight=pipe#my-piped-command-does-not-work-under-run
+
+  run bash -c 'kwctl run \
+    --request-path test_data/pod_creation_signed_with_pubkey_cosign_v3.json \
+    --settings-path test_data/settings-pubkey-cosign-v3.yaml \
+    annotated-policy.wasm 2>/dev/null | jq -r ".patch | @base64d"'
+
+  # this prints the output when one the checks below fails
+  echo "output = ${output}"
+
+  [ "$status" -eq 0 ]
+  [ $(expr "$output" : '.*ghcr.io/kubewarden/test-verify-image-signatures:signed-v3-only@sha256:706446e9c6667c0880d5da3f39c09a6c7d2114f5a5d6b74a2fafd24ae30d2078.*') -ne 0 ]
+}
+
+@test "Reject image with wrong public key using cosign v3 format" {
+  run kwctl run \
+    --request-path test_data/pod_creation_signed_with_pubkey_cosign_v3.json \
+    --settings-path test_data/settings-mutation-enabled.yaml \
+    annotated-policy.wasm
+
+  # this prints the output when one the checks below fails
+  echo "output = ${output}"
+
+  [ "$status" -eq 0 ]
+  [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+  [ $(expr "$output" : '.*verification of image ghcr.io/kubewarden/test-verify-image-signatures:signed-v3-only failed.*') -ne 0 ]
+}
+

--- a/policies/verify-image-signatures/test_data/pod_creation_signed_with_pubkey_cosign_v3.json
+++ b/policies/verify-image-signatures/test_data/pod_creation_signed_with_pubkey_cosign_v3.json
@@ -1,0 +1,39 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "group": "",
+    "kind": "Pod",
+    "version": "v1"
+  },
+  "resource": {
+    "group": "",
+    "version": "v1",
+    "resource": "pods"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "containers": [
+        {
+          "image": "ghcr.io/kubewarden/test-verify-image-signatures:signed-v3-only",
+          "name": "test-verify-image-signatures"
+        }
+      ]
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "group": "",
+    "version": "v1",
+    "kind": "Pod"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/policies/verify-image-signatures/test_data/settings-pubkey-cosign-v3.yaml
+++ b/policies/verify-image-signatures/test_data/settings-pubkey-cosign-v3.yaml
@@ -1,0 +1,11 @@
+# Settings to verify images signed with cosign v3 (OCI referrers / Sigstore bundle
+# format) using a public key. The image was signed without uploading to the Rekor
+# transparency log (--tlog-upload=false).
+signatures:
+  - image: "ghcr.io/kubewarden/test-verify-image-signatures:signed-v3-only"
+    pubKeys:
+      - |
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEALYYVLuPXXcKajo5meRcU+c6/iZe
+        Dh+o3ZZs1puVW5FyS1cOusnLn209R0IOFL479vm1iFn+auB41JJZUxfc8g==
+        -----END PUBLIC KEY-----


### PR DESCRIPTION
## Description

Push a new image that was only signed with v3 format:

```
$ cd policies/policies/verify-image-signatures/test_data/certificate-signing
$ make import-cosign.key bundle.pem
$ cat import-cosign.pub

-----BEGIN PUBLIC KEY-----
MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbtAEFHIjGEUuJFUXK5WbgYkEGah0
BpGdq9gM6XV43aoYpGo2xDsJlpJxGjjw0KFjdtghCFP6rat9UF2FaofO1Q==
-----END PUBLIC KEY-----

$ cosign sign --key import-cosign.key --new-bundle-format=true  ghcr.io/kubewarden/test-verify-image-signatures:signed-v3-only
$ cosign verify --key import-cosign.pub  ghcr.io/kubewarden/test-verify-image-signatures:signed-v3-only
```



<!-- Please provide the link to the GitHub issue you are addressing -->
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

The test fails with:
`Skipping Sigstore Bundle layer due to error: Sigstore Bundle v0.3: expected Certificate in verificationMaterial`

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
