### PR TITLE
fix(ci): allow queue job to update artifacthub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: artifacthub-branch-updates
-      cancel-in-progress: false
+      queue: max
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Description

Updates the release.yml workflow to allow CI to queue the job that updates the artifacthub branch when releasing the policies.

