### PR TITLE
ci: publish runtime-enforcer policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,6 @@ jobs:
             "raw-validation-policy"
             "raw-validation-wasi-policy"
             "sleeping-policy"
-            "runtime-enforcer-policy"
           )
           skip_publishing=false
           for excluded in "${EXCLUDED_FROM_PUBLISHING[@]}"; do


### PR DESCRIPTION
Publish the runtime-enforcer policy on ArtifactHub.

I think this is the only thing we need to do, aside from triggering the CI to run. Am I right?
