### PR TITLE
chore: add missing annotation

### DIFF
--- a/policies/runtime-enforcer-policy/metadata.yml
+++ b/policies/runtime-enforcer-policy/metadata.yml
@@ -61,3 +61,4 @@ annotations:
   # Category indicates policy category. See more here at docs.kubewarden.io
   io.kubewarden.policy.severity: medium # one of info, low, medium, high, critical. See docs.
   io.kubewarden.policy.category: Runtime Enforcer
+  com.github.release.tag: runtime-enforcer-policy/v0.1.1


### PR DESCRIPTION
## Description

To allow kwctl to proper build the metadata used by ArtifactHub to get the link the "com.github.release.tag: safe-annotations-policy/v1.0.5" annotations is missing. This commit add it to the metadata.yaml file.

This is necessary to proper release the policy.
