### PR TITLE
fix(trusted-repos): normalize uppercase domains to lowercase

### DIFF
--- a/policies/Cargo.lock
+++ b/policies/Cargo.lock
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "trusted-repos-policy"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "k8s-openapi 0.28.0",

--- a/policies/trusted-repos-policy/Cargo.toml
+++ b/policies/trusted-repos-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-repos-policy"
-version = "2.1.1"
+version = "2.1.2"
 authors = ["Kubewarden Developers <cncf-kubewarden-maintainers@lists.cncf.io>"]
 edition = "2024"
 

--- a/policies/trusted-repos-policy/metadata.yml
+++ b/policies/trusted-repos-policy/metadata.yml
@@ -25,7 +25,7 @@ annotations:
   # kubewarden specific
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/trusted-repos
   io.kubewarden.policy.title: trusted-repos
-  io.kubewarden.policy.version: 2.1.1
+  io.kubewarden.policy.version: 2.1.2
   io.kubewarden.policy.description: Kubewarden policy that restricts which registries, tags, and images pods in your cluster can refer to, with wildcard pattern support
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.url: https://github.com/kubewarden/policies
@@ -33,4 +33,4 @@ annotations:
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Secure supply chain
   io.kubewarden.policy.severity: medium
-  com.github.release.tag: trusted-repos-policy/v2.1.1
+  com.github.release.tag: trusted-repos-policy/v2.1.2

--- a/policies/trusted-repos-policy/src/matchers/image.rs
+++ b/policies/trusted-repos-policy/src/matchers/image.rs
@@ -1,19 +1,56 @@
 use std::{hash::Hash, str::FromStr};
 
-use oci_spec::distribution::Reference;
+use oci_spec::distribution::{ParseError, Reference};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use wildmatch::WildMatch;
 
 use crate::matchers::{is_glob_pattern, string::StringMatcher};
 
-/// Custom type to represent an image reference. It's required to implement
-/// the `Deserialize` trait to be able to use it in the `Settings` struct.
+/// Custom type to represent an image reference. It's required to implement the `Deserialize` trait
+/// to be able to use it in the `Settings` struct.
+///
+/// The registry hostname is normalized and always stored in lowercase: DNS hostnames are
+/// case-insensitive (RFC 4343) but `oci-spec` preserves whatever case the caller supplies. This
+/// ensures correct comparisons.
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct ImageRef(oci_spec::distribution::Reference);
 
 impl ImageRef {
-    pub fn new(reference: oci_spec::distribution::Reference) -> Self {
-        ImageRef(reference)
+    /// Build an `ImageRef` from an already-parsed `Reference`, normalising
+    /// the registry hostname to lowercase.  This is the single place where
+    /// the normalisation is enforced.
+    fn from_reference(r: Reference) -> Self {
+        let registry = r.registry();
+        let registry_lower = registry.to_lowercase();
+
+        if registry == registry_lower {
+            return ImageRef(r);
+        }
+
+        let rebuilt = match (r.tag(), r.digest()) {
+            (Some(tag), Some(digest)) => Reference::with_tag_and_digest(
+                registry_lower,
+                r.repository().to_owned(),
+                tag.to_owned(),
+                digest.to_owned(),
+            ),
+            (Some(tag), None) => {
+                Reference::with_tag(registry_lower, r.repository().to_owned(), tag.to_owned())
+            }
+            (None, Some(digest)) => {
+                Reference::with_digest(registry_lower, r.repository().to_owned(), digest.to_owned())
+            }
+            // After `Reference::from_str`, tag and digest are never both None
+            // (the parser inserts "latest" when both are absent), but handle
+            // the case exhaustively to satisfy the compiler
+            (None, None) => Reference::with_tag(
+                registry_lower,
+                r.repository().to_owned(),
+                "latest".to_owned(),
+            ),
+        };
+
+        ImageRef(rebuilt)
     }
 
     pub fn whole(&self) -> String {
@@ -27,11 +64,23 @@ impl ImageRef {
     pub fn registry(&self) -> &str {
         self.0.registry()
     }
+
+    pub fn tag(&self) -> Option<&str> {
+        self.0.tag()
+    }
+}
+
+impl FromStr for ImageRef {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Reference::from_str(s).map(ImageRef::from_reference)
+    }
 }
 
 impl From<Reference> for ImageRef {
     fn from(reference: Reference) -> Self {
-        ImageRef(reference)
+        ImageRef::from_reference(reference)
     }
 }
 
@@ -84,8 +133,8 @@ impl<'de> Deserialize<'de> for ImageMatcher {
                 raw: s,
             }))
         } else {
-            let reference = Reference::from_str(&s).map_err(serde::de::Error::custom)?;
-            Ok(ImageMatcher::Exact(ImageRef(reference)))
+            let image_ref = ImageRef::from_str(&s).map_err(serde::de::Error::custom)?;
+            Ok(ImageMatcher::Exact(image_ref))
         }
     }
 }
@@ -101,7 +150,7 @@ impl Serialize for ImageMatcher {
 
 impl From<Reference> for ImageMatcher {
     fn from(reference: Reference) -> Self {
-        ImageMatcher::Exact(ImageRef(reference))
+        ImageMatcher::Exact(ImageRef::from(reference))
     }
 }
 
@@ -114,7 +163,7 @@ mod tests {
     use crate::settings::Images;
 
     fn exact_image(s: &str) -> ImageMatcher {
-        ImageMatcher::Exact(ImageRef(Reference::from_str(s).unwrap()))
+        ImageMatcher::Exact(ImageRef::from_str(s).unwrap())
     }
 
     fn pattern_image(s: &str) -> ImageMatcher {

--- a/policies/trusted-repos-policy/src/validation.rs
+++ b/policies/trusted-repos-policy/src/validation.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashSet, str::FromStr};
 
 use k8s_openapi::api::core::v1 as apicore;
-use oci_spec::distribution::Reference;
 
 use crate::{
     matchers::image::{ImageMatcher, ImageRef},
@@ -24,7 +23,7 @@ fn validate_images(images: &HashSet<&str>, settings: &Settings) -> PodSpecValida
     let mut rejection_reasons = PodRejectionReasons::default();
 
     for image in images {
-        let image_ref = Reference::from_str(image);
+        let image_ref = ImageRef::from_str(image);
         if let Ok(image_ref) = image_ref {
             if !is_allowed_registry(image_ref.registry(), settings) {
                 rejection_reasons
@@ -37,7 +36,7 @@ fn validate_images(images: &HashSet<&str>, settings: &Settings) -> PodSpecValida
                 rejection_reasons.tags_not_allowed.insert(tag.to_owned());
             }
 
-            if !is_allowed_image(&image_ref.into(), settings) {
+            if !is_allowed_image(&image_ref, settings) {
                 rejection_reasons
                     .images_not_allowed
                     .insert(image.to_string());
@@ -136,9 +135,10 @@ fn image_matches_any(image_ref: &ImageRef, matchers: &HashSet<ImageMatcher>) -> 
             }
 
             // Loose match: repository only (without registry, tag, or digest)
-            let contained_in_set_with_same_repo = Reference::from_str(image_ref.repository())
+            let contained_in_set_with_same_repo = ImageRef::from_str(image_ref.repository())
                 .ok()
-                .map(|r| &ImageRef::new(r) == exact_ref)
+                .as_ref()
+                .map(|r| r == exact_ref)
                 .unwrap_or(false);
             if contained_in_set_with_same_repo {
                 return true;
@@ -146,9 +146,10 @@ fn image_matches_any(image_ref: &ImageRef, matchers: &HashSet<ImageMatcher>) -> 
 
             // Loose match: registry + repository (without tag or digest)
             let registry_repo = format!("{}/{}", image_ref.registry(), image_ref.repository());
-            Reference::from_str(&registry_repo)
+            ImageRef::from_str(&registry_repo)
                 .ok()
-                .map(|r| &ImageRef::new(r) == exact_ref)
+                .as_ref()
+                .map(|r| r == exact_ref)
                 .unwrap_or(false)
         }
         ImageMatcher::Pattern(sm) => {
@@ -248,7 +249,7 @@ mod tests {
     }
 
     fn exact_image(s: &str) -> ImageMatcher {
-        ImageMatcher::Exact(ImageRef::new(Reference::from_str(s).unwrap()))
+        ImageMatcher::Exact(ImageRef::from_str(s).unwrap())
     }
 
     fn pattern_image(s: &str) -> ImageMatcher {

--- a/policies/trusted-repos-policy/src/validation.rs
+++ b/policies/trusted-repos-policy/src/validation.rs
@@ -983,4 +983,71 @@ mod tests {
             "got: {result:?} instead of {expected_result:?}"
         );
     }
+
+    #[test]
+    fn hostcase_registry_reject_uppercase_domain() {
+        let settings = Settings {
+            registries: Registries {
+                reject: ["evil-registry.com".to_string()]
+                    .into_iter()
+                    .map(|s| RegistryMatcher(StringMatcher::Exact(s)))
+                    .collect(),
+                ..Registries::default()
+            },
+            ..Settings::default()
+        };
+
+        let lower: HashSet<&str> = ["evil-registry.com/malware:v1"].into_iter().collect();
+        let upper: HashSet<&str> = ["EVIL-REGISTRY.COM/malware:v1"].into_iter().collect();
+
+        // lowercase is correctly rejected
+        let lower_result = validate_images(&lower, &settings);
+        assert!(
+            matches!(lower_result, PodSpecValidationResult::NotAllowed(_)),
+            "lowercase should be rejected, got: {lower_result:?}"
+        );
+        // uppercase must also be rejected (same host per DNS)
+        let upper_result = validate_images(&upper, &settings);
+        assert!(
+            matches!(upper_result, PodSpecValidationResult::NotAllowed(_)),
+            "UPPERCASE should be rejected too, got: {upper_result:?}"
+        );
+    }
+
+    #[test]
+    fn oci_ref_uppercase_normalization() {
+        let lower = ImageRef::from_str("evil-registry.com/malware:v1").unwrap();
+        let upper = ImageRef::from_str("EVIL-REGISTRY.COM/malware:v1").unwrap();
+        // After our normalisation both inputs yield the same lowercase registry
+        assert_eq!(lower.registry(), "evil-registry.com");
+        assert_eq!(upper.registry(), "evil-registry.com");
+        assert_eq!(lower.registry(), upper.registry());
+    }
+
+    #[test]
+    fn hostcase_image_reject_uppercase_domain() {
+        let settings = Settings {
+            images: Images {
+                reject: [exact_image("evil-registry.com/malware")]
+                    .into_iter()
+                    .collect(),
+                ..Images::default()
+            },
+            ..Settings::default()
+        };
+
+        let lower: HashSet<&str> = ["evil-registry.com/malware:v1"].into_iter().collect();
+        let upper: HashSet<&str> = ["EVIL-REGISTRY.COM/malware:v1"].into_iter().collect();
+
+        let lower_result = validate_images(&lower, &settings);
+        assert!(
+            matches!(lower_result, PodSpecValidationResult::NotAllowed(_)),
+            "lowercase should be rejected, got: {lower_result:?}"
+        );
+        let upper_result = validate_images(&upper, &settings);
+        assert!(
+            matches!(upper_result, PodSpecValidationResult::NotAllowed(_)),
+            "UPPERCASE image registry should be rejected too, got: {upper_result:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

For deny-lists, we must normalize uppercase domains to lowercase,
as DNS is case insensitive, and we want to match a registry or an image
with an uppercase host (e.g: `EVIL-REGISTRY.COM/malware`) with a
reject entry for `evil-registry.com`.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Added unit tests.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
